### PR TITLE
appveyor.yml tbv bouwen/testen op Win64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+version: '{build}-({branch})'
+
+skip_tags: true
+
+shallow_clone: true
+
+environment:
+  fast_finish: true
+  matrix:
+  - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
+    JDK: JDK7
+  - JDK: JDK8
+    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+
+install:
+- set MVN_VERSION=3.2.5
+- set PATH=%PATH%;C:\bin\apache-maven-%MVN_VERSION%\bin
+- IF NOT exist "C:\bin\apache-maven-%MVN_VERSION%\bin\*.*" (echo Maven %MVN_VERSION% not installed, so install it & cinst maven -Version %MVN_VERSION%) ELSE (echo Maven %MVN_VERSION% already installed)
+- mvn install -U -Dmaven.test.skip=true -B -V -fae -q -T2
+
+cache:
+- C:\bin\apache-maven-%MVN_VERSION%
+- C:\Users\appveyor\.m2\repository
+
+test_script:
+- mvn -e test verify -B


### PR DESCRIPTION
Appveyor gebruiken om windows builds te doen (zoals nu met Travis-CI op linux gebeurd, zie: #304).

Bouwt op Windows 2012R2 x64 met JDK 7 en JDK 8 mbv. Maven 3.2.5.

  - Gebruikt de  shallow clone optie om .zip van github branches te downloaden (sneller dan git checkout)
  - skips git tags (dwz alleen branches worden gebouwd/getest)

Om dit te activeren voor flamingo-geocms/flamingo moet de repository nog even aangemeld worden op https://ci.appveyor.com .
Aanmelden met github account door een project admin en dan "add project"...

Voorbeeld: https://ci.appveyor.com/project/mprins/flamingo

Nadat dit gemerged is kan er ook nog zo'n kekke badge bij in de readme.